### PR TITLE
Update provides port information for TopoFlow components

### DIFF
--- a/channels_diffusive_wave/db/provides.json
+++ b/channels_diffusive_wave/db/provides.json
@@ -1,46 +1,6 @@
 [
   {
-    "id": "", 
-    "required": false, 
-    "exchange_items": [
-      "canals_entrance_water__volume_flow_rate", 
-      "channel_bottom_surface__slope", 
-      "channel_bottom_water_flow__log_law_roughness_length", 
-      "channel_bottom_water_flow__magnitude_of_shear_stress", 
-      "channel_bottom_water_flow__shear_speed", 
-      "channel_centerline__sinuosity", 
-      "channel_water_flow__froude_number", 
-      "channel_water_flow__half_of_fanning_friction_factor", 
-      "channel_water_flow__manning_n_parameter", 
-      "channel_water_surface__slope", 
-      "channel_water_x-section__hydraulic_radius", 
-      "channel_water_x-section__initial_mean_depth", 
-      "channel_water_x-section__volume_flow_rate", 
-      "channel_water_x-section__volume_flux", 
-      "channel_water_x-section__wetted_area", 
-      "channel_water_x-section__wetted_perimeter", 
-      "channel_x-section_trapezoid_bottom__width", 
-      "channel_x-section_trapezoid_side__flare_angle", 
-      "model__time_step", 
-      "model_grid_cell__area"
-    ]
-  }, 
-  {
-    "id": "diversions", 
-    "required": false, 
-    "exchange_items": [
-      "channel_water__volume"
-    ]
-  }, 
-  {
-    "id": "evap", 
-    "required": false, 
-    "exchange_items": [
-      "channel_water_x-section__mean_depth"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
+    "id": "channels", 
     "required": false, 
     "exchange_items": [
       "basin_outlet_water_flow__half_of_fanning_friction_factor", 
@@ -54,25 +14,40 @@
       "basin_outlet_water_x-section__time_max_of_volume_flux", 
       "basin_outlet_water_x-section__volume_flow_rate", 
       "basin_outlet_water_x-section__volume_flux", 
+      "canals_entrance_water__volume_flow_rate", 
+      "channel_bottom_surface__slope", 
       "channel_bottom_water_flow__domain_max_of_log_law_roughness_length", 
       "channel_bottom_water_flow__domain_min_of_log_law_roughness_length", 
+      "channel_bottom_water_flow__log_law_roughness_length", 
+      "channel_bottom_water_flow__magnitude_of_shear_stress", 
+      "channel_bottom_water_flow__shear_speed", 
+      "channel_centerline__sinuosity", 
+      "channel_water__volume",
+      "channel_water_flow__froude_number", 
+      "channel_water_flow__half_of_fanning_friction_factor", 
       "channel_water_flow__domain_max_of_manning_n_parameter", 
       "channel_water_flow__domain_min_of_manning_n_parameter", 
+      "channel_water_flow__manning_n_parameter", 
+      "channel_water_surface__slope", 
       "channel_water_x-section__domain_max_of_mean_depth", 
       "channel_water_x-section__domain_min_of_mean_depth", 
       "channel_water_x-section__domain_max_of_volume_flow_rate", 
       "channel_water_x-section__domain_min_of_volume_flow_rate", 
       "channel_water_x-section__domain_max_of_volume_flux", 
       "channel_water_x-section__domain_min_of_volume_flux", 
+      "channel_water_x-section__hydraulic_radius", 
+      "channel_water_x-section__initial_mean_depth", 
+      "channel_water_x-section__mean_depth",
+      "channel_water_x-section__volume_flow_rate", 
+      "channel_water_x-section__volume_flux", 
+      "channel_water_x-section__wetted_area", 
+      "channel_water_x-section__wetted_perimeter", 
+      "channel_x-section_trapezoid_bottom__width", 
+      "channel_x-section_trapezoid_side__flare_angle", 
       "land_surface_water__runoff_volume_flux", 
-      "land_surface_water__domain_time_integral_of_runoff_volume_flux"
-    ]
-  }, 
-  {
-    "id": "satzone", 
-    "required": false, 
-    "exchange_items": [
-      "channel_water_x-section__mean_depth"
+      "land_surface_water__domain_time_integral_of_runoff_volume_flux",
+      "model__time_step", 
+      "model_grid_cell__area"
     ]
   }
 ]

--- a/channels_dynamic_wave/db/provides.json
+++ b/channels_dynamic_wave/db/provides.json
@@ -1,46 +1,6 @@
 [
   {
-    "id": "", 
-    "required": false, 
-    "exchange_items": [
-      "canals_entrance_water__volume_flow_rate", 
-      "channel_bottom_surface__slope", 
-      "channel_bottom_water_flow__log_law_roughness_length", 
-      "channel_bottom_water_flow__magnitude_of_shear_stress", 
-      "channel_bottom_water_flow__shear_speed", 
-      "channel_centerline__sinuosity", 
-      "channel_water_flow__froude_number", 
-      "channel_water_flow__half_of_fanning_friction_factor", 
-      "channel_water_flow__manning_n_parameter", 
-      "channel_water_surface__slope", 
-      "channel_water_x-section__hydraulic_radius", 
-      "channel_water_x-section__initial_mean_depth", 
-      "channel_water_x-section__volume_flow_rate", 
-      "channel_water_x-section__volume_flux", 
-      "channel_water_x-section__wetted_area", 
-      "channel_water_x-section__wetted_perimeter", 
-      "channel_x-section_trapezoid_bottom__width", 
-      "channel_x-section_trapezoid_side__flare_angle", 
-      "model__time_step", 
-      "model_grid_cell__area"
-    ]
-  }, 
-  {
-    "id": "diversions", 
-    "required": false, 
-    "exchange_items": [
-      "channel_water__volume"
-    ]
-  }, 
-  {
-    "id": "evap", 
-    "required": false, 
-    "exchange_items": [
-      "channel_water_x-section__mean_depth"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
+    "id": "channels", 
     "required": false, 
     "exchange_items": [
       "basin_outlet_water_flow__half_of_fanning_friction_factor", 
@@ -54,25 +14,40 @@
       "basin_outlet_water_x-section__time_max_of_volume_flux", 
       "basin_outlet_water_x-section__volume_flow_rate", 
       "basin_outlet_water_x-section__volume_flux", 
+      "canals_entrance_water__volume_flow_rate", 
+      "channel_bottom_surface__slope", 
       "channel_bottom_water_flow__domain_max_of_log_law_roughness_length", 
       "channel_bottom_water_flow__domain_min_of_log_law_roughness_length", 
+      "channel_bottom_water_flow__log_law_roughness_length", 
+      "channel_bottom_water_flow__magnitude_of_shear_stress", 
+      "channel_bottom_water_flow__shear_speed", 
+      "channel_centerline__sinuosity", 
+      "channel_water__volume",
+      "channel_water_flow__froude_number", 
+      "channel_water_flow__half_of_fanning_friction_factor", 
       "channel_water_flow__domain_max_of_manning_n_parameter", 
       "channel_water_flow__domain_min_of_manning_n_parameter", 
+      "channel_water_flow__manning_n_parameter", 
+      "channel_water_surface__slope", 
       "channel_water_x-section__domain_max_of_mean_depth", 
       "channel_water_x-section__domain_min_of_mean_depth", 
       "channel_water_x-section__domain_max_of_volume_flow_rate", 
       "channel_water_x-section__domain_min_of_volume_flow_rate", 
       "channel_water_x-section__domain_max_of_volume_flux", 
       "channel_water_x-section__domain_min_of_volume_flux", 
+      "channel_water_x-section__hydraulic_radius", 
+      "channel_water_x-section__initial_mean_depth", 
+      "channel_water_x-section__mean_depth",
+      "channel_water_x-section__volume_flow_rate", 
+      "channel_water_x-section__volume_flux", 
+      "channel_water_x-section__wetted_area", 
+      "channel_water_x-section__wetted_perimeter", 
+      "channel_x-section_trapezoid_bottom__width", 
+      "channel_x-section_trapezoid_side__flare_angle", 
       "land_surface_water__runoff_volume_flux", 
-      "land_surface_water__domain_time_integral_of_runoff_volume_flux"
-    ]
-  }, 
-  {
-    "id": "satzone", 
-    "required": false, 
-    "exchange_items": [
-      "channel_water_x-section__mean_depth"
+      "land_surface_water__domain_time_integral_of_runoff_volume_flux",
+      "model__time_step", 
+      "model_grid_cell__area"
     ]
   }
 ]

--- a/channels_kinematic_wave/db/provides.json
+++ b/channels_kinematic_wave/db/provides.json
@@ -1,46 +1,6 @@
 [
   {
-    "id": "", 
-    "required": false, 
-    "exchange_items": [
-      "canals_entrance_water__volume_flow_rate", 
-      "channel_bottom_surface__slope", 
-      "channel_bottom_water_flow__log_law_roughness_length", 
-      "channel_bottom_water_flow__magnitude_of_shear_stress", 
-      "channel_bottom_water_flow__shear_speed", 
-      "channel_centerline__sinuosity", 
-      "channel_water_flow__froude_number", 
-      "channel_water_flow__half_of_fanning_friction_factor", 
-      "channel_water_flow__manning_n_parameter", 
-      "channel_water_surface__slope", 
-      "channel_water_x-section__hydraulic_radius", 
-      "channel_water_x-section__initial_mean_depth", 
-      "channel_water_x-section__volume_flow_rate", 
-      "channel_water_x-section__volume_flux", 
-      "channel_water_x-section__wetted_area", 
-      "channel_water_x-section__wetted_perimeter", 
-      "channel_x-section_trapezoid_bottom__width", 
-      "channel_x-section_trapezoid_side__flare_angle", 
-      "model__time_step", 
-      "model_grid_cell__area"
-    ]
-  }, 
-  {
-    "id": "diversions", 
-    "required": false, 
-    "exchange_items": [
-      "channel_water__volume"
-    ]
-  }, 
-  {
-    "id": "evap", 
-    "required": false, 
-    "exchange_items": [
-      "channel_water_x-section__mean_depth"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
+    "id": "channels", 
     "required": false, 
     "exchange_items": [
       "basin_outlet_water_flow__half_of_fanning_friction_factor", 
@@ -54,25 +14,40 @@
       "basin_outlet_water_x-section__time_max_of_volume_flux", 
       "basin_outlet_water_x-section__volume_flow_rate", 
       "basin_outlet_water_x-section__volume_flux", 
+      "canals_entrance_water__volume_flow_rate", 
+      "channel_bottom_surface__slope", 
       "channel_bottom_water_flow__domain_max_of_log_law_roughness_length", 
       "channel_bottom_water_flow__domain_min_of_log_law_roughness_length", 
+      "channel_bottom_water_flow__log_law_roughness_length", 
+      "channel_bottom_water_flow__magnitude_of_shear_stress", 
+      "channel_bottom_water_flow__shear_speed", 
+      "channel_centerline__sinuosity", 
+      "channel_water__volume",
+      "channel_water_flow__froude_number", 
+      "channel_water_flow__half_of_fanning_friction_factor", 
       "channel_water_flow__domain_max_of_manning_n_parameter", 
       "channel_water_flow__domain_min_of_manning_n_parameter", 
+      "channel_water_flow__manning_n_parameter", 
+      "channel_water_surface__slope", 
       "channel_water_x-section__domain_max_of_mean_depth", 
       "channel_water_x-section__domain_min_of_mean_depth", 
       "channel_water_x-section__domain_max_of_volume_flow_rate", 
       "channel_water_x-section__domain_min_of_volume_flow_rate", 
       "channel_water_x-section__domain_max_of_volume_flux", 
       "channel_water_x-section__domain_min_of_volume_flux", 
+      "channel_water_x-section__hydraulic_radius", 
+      "channel_water_x-section__initial_mean_depth", 
+      "channel_water_x-section__mean_depth",
+      "channel_water_x-section__volume_flow_rate", 
+      "channel_water_x-section__volume_flux", 
+      "channel_water_x-section__wetted_area", 
+      "channel_water_x-section__wetted_perimeter", 
+      "channel_x-section_trapezoid_bottom__width", 
+      "channel_x-section_trapezoid_side__flare_angle", 
       "land_surface_water__runoff_volume_flux", 
-      "land_surface_water__domain_time_integral_of_runoff_volume_flux"
-    ]
-  }, 
-  {
-    "id": "satzone", 
-    "required": false, 
-    "exchange_items": [
-      "channel_water_x-section__mean_depth"
+      "land_surface_water__domain_time_integral_of_runoff_volume_flux",
+      "model__time_step", 
+      "model_grid_cell__area"
     ]
   }
 ]

--- a/diversions_fraction_method/db/provides.json
+++ b/diversions_fraction_method/db/provides.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "", 
+    "id": "diversions", 
     "required": false, 
     "exchange_items": [
       "canals__count", 

--- a/diversions_standard/db/provides.json
+++ b/diversions_standard/db/provides.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "diversions_standard", 
+    "id": "diversions", 
     "required": false
   }
 ]

--- a/evap_energy_balance/db/provides.json
+++ b/evap_energy_balance/db/provides.json
@@ -1,38 +1,12 @@
 [
   {
-    "id": "", 
+    "id": "evap", 
     "required": false, 
     "exchange_items": [
       "land_surface_soil__conduction_heat_flux", 
+      "land_surface_water__domain_time_integral_of_evaporation_volume_flux",
+      "land_surface_water__evaporation_volume_flux",
       "model__time_step"
-    ]
-  }, 
-  {
-    "id": "channels", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__evaporation_volume_flux"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__domain_time_integral_of_evaporation_volume_flux"
-    ]
-  }, 
-  {
-    "id": "satzone", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__evaporation_volume_flux"
-    ]
-  }, 
-  {
-    "id": "infil", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__evaporation_volume_flux"
     ]
   }
 ]

--- a/evap_priestley_taylor/db/provides.json
+++ b/evap_priestley_taylor/db/provides.json
@@ -1,38 +1,12 @@
 [
   {
-    "id": "", 
+    "id": "evap", 
     "required": false, 
     "exchange_items": [
       "land_surface_soil__conduction_heat_flux", 
+      "land_surface_water__domain_time_integral_of_evaporation_volume_flux",
+      "land_surface_water__evaporation_volume_flux",
       "model__time_step"
-    ]
-  }, 
-  {
-    "id": "channels", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__evaporation_volume_flux"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__domain_time_integral_of_evaporation_volume_flux"
-    ]
-  }, 
-  {
-    "id": "satzone", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__evaporation_volume_flux"
-    ]
-  }, 
-  {
-    "id": "infil", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__evaporation_volume_flux"
     ]
   }
 ]

--- a/evap_read_file/db/provides.json
+++ b/evap_read_file/db/provides.json
@@ -1,38 +1,12 @@
 [
   {
-    "id": "channels", 
+    "id": "evap", 
     "required": false, 
     "exchange_items": [
-      "land_surface_water__evaporation_volume_flux"
-    ]
-  }, 
-  {
-    "id": "satzone", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__evaporation_volume_flux"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__domain_time_integral_of_evaporation_volume_flux"
-    ]
-  }, 
-  {
-    "id": "", 
-    "required": false, 
-    "exchange_items": [
+      "land_surface_water__evaporation_volume_flux",
+      "land_surface_water__domain_time_integral_of_evaporation_volume_flux",
       "model_grid_cell__area", 
       "model__time_step"
-    ]
-  }, 
-  {
-    "id": "infil", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface_water__evaporation_volume_flux"
     ]
   }
 ]

--- a/ice_gc2d/db/provides.json
+++ b/ice_gc2d/db/provides.json
@@ -1,34 +1,15 @@
 [
   {
-    "id": "channels", 
+    "id": "ice", 
     "required": false, 
     "exchange_items": [
-      "glacier_ice__melt_volume_flux"
-    ]
-  }, 
-  {
-    "id": "", 
-    "required": false, 
-    "exchange_items": [
+      "glacier_ice__domain_time_integral_of_melt_volume_flux",
+      "glacier_ice__melt_volume_flux",
       "glacier_top_surface__elevation", 
       "glacier_ice__thickness", 
       "model_grid_cell__x_length", 
       "model_grid_cell__y_length", 
       "model__time_step"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
-    "required": false, 
-    "exchange_items": [
-      "glacier_ice__domain_time_integral_of_melt_volume_flux"
-    ]
-  }, 
-  {
-    "id": "infil", 
-    "required": false, 
-    "exchange_items": [
-      "glacier_ice__melt_volume_flux"
     ]
   }
 ]

--- a/infil_beven/db/provides.json
+++ b/infil_beven/db/provides.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "infil_beven", 
+    "id": "infil", 
     "required": false
   }
 ]

--- a/infil_green_ampt/db/provides.json
+++ b/infil_green_ampt/db/provides.json
@@ -1,24 +1,21 @@
 [
   {
-    "id": "", 
+    "id": "infil", 
     "required": false, 
     "exchange_items": [
-      "canals__count", 
-      "canals_entrance_water__volume_fraction", 
-      "canals_entrance__x_coordinate", 
-      "canals_entrance__y_coordinate", 
-      "canals_exit_water__volume_flow_rate", 
-      "canals_exit__x_coordinate", 
-      "canals_exit__y_coordinate", 
-      "model__time_step", 
-      "sinks_water__volume_flow_rate", 
-      "sinks__count", 
-      "sinks__x_coordinate", 
-      "sinks__y_coordinate", 
-      "sources_water__volume_flow_rate", 
-      "sources__count", 
-      "sources__x_coordinate", 
-      "sources__y_coordinate"
+        "model__time_step",
+        "soil_surface_water__domain_time_integral_of_infiltration_volume_flux",
+        "soil_surface_water__infiltration_volume_flux",
+        "soil_surface_water__time_integral_of_infiltration_volume_flux",
+        "soil_water__green-ampt_capillary_length",
+        "soil_water__potential_infiltration_volume_flux",
+        "soil_water__initial_hydraulic_conductivity",
+        "soil_water__initial_volume_fraction",
+        "soil_water__saturated_hydraulic_conductivity",
+        "soil_water__saturated_volume_fraction",
+        "soil_water_flow__z_component_of_darcy_velocity",
+        "soil_water_sat-zone_top__domain_time_integral_of_recharge_volume_flux",
+        "soil_water_sat-zone_top__recharge_volume_flux"
     ]
   }
 ]

--- a/infil_richards_1d/db/provides.json
+++ b/infil_richards_1d/db/provides.json
@@ -1,9 +1,11 @@
 [
   {
-    "id": "", 
+    "id": "infil", 
     "required": false, 
     "exchange_items": [
       "model__time_step", 
+      "soil_surface_water__domain_time_integral_of_infiltration_volume_flux", 
+      "soil_surface_water__infiltration_volume_flux",
       "soil_surface_water__volume_fraction", 
       "soil_water__brooks-corey_eta_parameter", 
       "soil_water__brooks-corey_lambda_parameter", 
@@ -20,29 +22,9 @@
       "soil_water__saturated_volume_fraction", 
       "soil_water__volume_fraction", 
       "soil_water_flow__z_component_of_darcy_velocity", 
+      "soil_water_sat-zone_top__domain_time_integral_of_recharge_volume_flux",
+      "soil_water_sat-zone_top__recharge_volume_flux",
       "soil_water_wetting-front__depth"
-    ]
-  }, 
-  {
-    "id": "channels", 
-    "required": false, 
-    "exchange_items": [
-      "soil_surface_water__infiltration_volume_flux"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
-    "required": false, 
-    "exchange_items": [
-      "soil_surface_water__domain_time_integral_of_infiltration_volume_flux", 
-      "soil_water_sat-zone_top__domain_time_integral_of_recharge_volume_flux"
-    ]
-  }, 
-  {
-    "id": "satzone", 
-    "required": false, 
-    "exchange_items": [
-      "soil_water_sat-zone_top__recharge_volume_flux"
     ]
   }
 ]

--- a/infil_smith_parlange/db/provides.json
+++ b/infil_smith_parlange/db/provides.json
@@ -4,6 +4,8 @@
     "required": false, 
     "exchange_items": [
       "model__time_step", 
+      "soil_surface_water__domain_time_integral_of_infiltration_volume_flux", 
+      "soil_surface_water__infiltration_volume_flux",
       "soil_surface_water__time_integral_of_infiltration_volume_flux", 
       "soil_water__green-ampt_capillary_length", 
       "soil_water__potential_infiltration_volume_flux", 
@@ -12,28 +14,8 @@
       "soil_water__saturated_hydraulic_conductivity", 
       "soil_water__saturated_volume_fraction", 
       "soil_water__smith-parlange_gamma_parameter", 
-      "soil_water_flow__z_component_of_darcy_velocity"
-    ]
-  }, 
-  {
-    "id": "channels", 
-    "required": false, 
-    "exchange_items": [
-      "soil_surface_water__infiltration_volume_flux"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
-    "required": false, 
-    "exchange_items": [
-      "soil_surface_water__domain_time_integral_of_infiltration_volume_flux", 
-      "soil_water_sat-zone_top__domain_time_integral_of_recharge_volume_flux"
-    ]
-  }, 
-  {
-    "id": "satzone", 
-    "required": false, 
-    "exchange_items": [
+      "soil_water_flow__z_component_of_darcy_velocity",
+      "soil_water_sat-zone_top__domain_time_integral_of_recharge_volume_flux",
       "soil_water_sat-zone_top__recharge_volume_flux"
     ]
   }

--- a/infil_smith_parlange/db/provides.json
+++ b/infil_smith_parlange/db/provides.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "", 
+    "id": "infil", 
     "required": false, 
     "exchange_items": [
       "model__time_step", 

--- a/meteorology/db/provides.json
+++ b/meteorology/db/provides.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "", 
+    "id": "meteorology", 
     "required": false, 
     "exchange_items": [
       "atmosphere_aerosol_dust__reduction_of_transmittance", 
@@ -10,18 +10,26 @@
       "atmosphere_bottom_air__bulk_latent_heat_aerodynamic_conductance", 
       "atmosphere_bottom_air__bulk_sensible_heat_aerodynamic_conductance", 
       "atmosphere_bottom_air__emissivity", 
+      "atmosphere_bottom_air__mass-per-volume_density", 
+      "atmosphere_bottom_air__mass-specific_isobaric_heat_capacity", 
       "atmosphere_bottom_air__neutral_bulk_aerodynamic_conductance", 
       "atmosphere_bottom_air__pressure", 
+      "atmosphere_bottom_air__temperature", 
       "atmosphere_bottom_air_flow__bulk_richardson_number", 
       "atmosphere_bottom_air_flow__log_law_roughness_length", 
       "atmosphere_bottom_air_flow__reference-height_speed", 
       "atmosphere_bottom_air_flow__speed_reference_height", 
+      "atmosphere_bottom_air_land_net-latent-heat__energy_flux", 
       "atmosphere_bottom_air_land_net-sensible-heat__energy_flux", 
       "atmosphere_bottom_air_water-vapor__dew_point_temperature", 
       "atmosphere_bottom_air_water-vapor__partial_pressure", 
       "atmosphere_bottom_air_water-vapor__relative_saturation", 
       "atmosphere_bottom_air_water-vapor__saturated_partial_pressure", 
+      "atmosphere_water__domain_time_integral_of_precipitation_leq-volume_flux", 
+      "atmosphere_water__domain_time_max_of_precipitation_leq-volume_flux",
       "atmosphere_water__precipitation_leq-volume_flux", 
+      "atmosphere_water__rainfall_volume_flux",
+      "atmosphere_water__snowfall_leq-volume_flux", 
       "earth__standard_gravity_constant", 
       "land_surface__albedo", 
       "land_surface__aspect_angle", 
@@ -29,61 +37,18 @@
       "land_surface__latitude", 
       "land_surface__longitude", 
       "land_surface__slope_angle", 
+      "land_surface__temperature", 
       "land_surface_air_water-vapor__partial_pressure", 
       "land_surface_air_water-vapor__saturated_partial_pressure", 
+      "land_surface_net-longwave-radiation__energy_flux", 
+      "land_surface_net-shortwave-radiation__energy_flux", 
+      "land_surface_net-total-energy__energy_flux",
       "model__time_step", 
       "physics__stefan_boltzmann_constant", 
       "physics__von_karman_constant", 
       "water__mass-specific_latent_fusion_heat", 
-      "water__mass-specific_latent_vaporization_heat"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
-    "required": false, 
-    "exchange_items": [
-      "atmosphere_water__domain_time_integral_of_precipitation_leq-volume_flux", 
-      "atmosphere_water__domain_time_max_of_precipitation_leq-volume_flux"
-    ]
-  }, 
-  {
-    "id": "evap", 
-    "required": false, 
-    "exchange_items": [
-      "atmosphere_bottom_air__temperature", 
-      "atmosphere_bottom_air_land_net-latent-heat__energy_flux", 
-      "land_surface__temperature", 
-      "land_surface_net-longwave-radiation__energy_flux", 
-      "land_surface_net-shortwave-radiation__energy_flux", 
-      "land_surface_net-total-energy__energy_flux"
-    ]
-  }, 
-  {
-    "id": "snow", 
-    "required": false, 
-    "exchange_items": [
-      "atmosphere_bottom_air__mass-per-volume_density", 
-      "atmosphere_bottom_air__mass-specific_isobaric_heat_capacity", 
-      "atmosphere_bottom_air__temperature", 
-      "atmosphere_water__snowfall_leq-volume_flux", 
-      "land_surface__temperature", 
-      "land_surface_net-total-energy__energy_flux", 
+      "water__mass-specific_latent_vaporization_heat",
       "water-liquid__mass-per-volume_density"
     ]
-  }, 
-  {
-    "id": "infil", 
-    "required": false, 
-    "exchange_items": [
-      "atmosphere_water__rainfall_volume_flux"
-    ]
-  }, 
-  {
-    "id": "channels", 
-    "required": false, 
-    "exchange_items": [
-      "atmosphere_water__rainfall_volume_flux", 
-      "water-liquid__mass-per-volume_density"
-    ]
-  }
+  } 
 ]

--- a/satzone_darcy_layers/db/provides.json
+++ b/satzone_darcy_layers/db/provides.json
@@ -1,39 +1,25 @@
 [
   {
-    "id": "channels", 
+    "id": "satzone", 
     "required": false, 
     "exchange_items": [
-      "land_surface_water__baseflow_volume_flux"
-    ]
-  }, 
-  {
-    "id": "", 
-    "required": false, 
-    "exchange_items": [
-      "model__time_step", 
-      "model_soil_layer-0__porosity"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
-    "required": false, 
-    "exchange_items": [
+      "land_surface__elevation",
       "land_surface_water__baseflow_volume_flux", 
-      "land_surface_water__domain_time_integral_of_baseflow_volume_flux"
-    ]
-  }, 
-  {
-    "id": "d8", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface__elevation"
-    ]
-  }, 
-  {
-    "id": "infil", 
-    "required": false, 
-    "exchange_items": [
-      "land_surface__elevation"
+      "land_surface_water__domain_time_integral_of_baseflow_volume_flux",
+      "model__time_step", 
+      "model_soil_layer-0__porosity",
+      "model_soil_layer-0__saturated_thickness",
+      "model_soil_layer-0__thickness",
+      "model_soil_layer-1__porosity",
+      "model_soil_layer-1__saturated_thickness",
+      "model_soil_layer-1__thickness",
+      "model_soil_layer-2__porosity",
+      "model_soil_layer-2__saturated_thickness",
+      "model_soil_layer-2__thickness",
+      "soil_water_sat-zone_top_surface__elevation",
+      "soil_top-layer__porosity",
+      "soil_top-layer__saturated_thickness",
+      "soil_top-layer__thickness"
     ]
   }
 ]

--- a/snow_degree_day/db/provides.json
+++ b/snow_degree_day/db/provides.json
@@ -1,50 +1,17 @@
 [
   {
-    "id": "", 
+    "id": "snow", 
     "required": false, 
     "exchange_items": [
       "model__time_step", 
       "snowpack__degree-day_coefficient", 
       "snowpack__degree-day_threshold_temperature", 
+      "snowpack__domain_time_integral_of_melt_volume_flux",
+      "snowpack__depth",
       "snowpack__initial_depth", 
-      "snowpack__initial_liquid-equivalent_depth"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
-    "required": false, 
-    "exchange_items": [
-      "snowpack__domain_time_integral_of_melt_volume_flux"
-    ]
-  }, 
-  {
-    "id": "evap", 
-    "required": false, 
-    "exchange_items": [
-      "snowpack__depth"
-    ]
-  }, 
-  {
-    "id": "infil", 
-    "required": false, 
-    "exchange_items": [
-      "snowpack__melt_volume_flux"
-    ]
-  }, 
-  {
-    "id": "channels", 
-    "required": false, 
-    "exchange_items": [
-      "snowpack__melt_volume_flux"
-    ]
-  }, 
-  {
-    "id": "met", 
-    "required": false, 
-    "exchange_items": [
-      "snowpack__depth", 
+      "snowpack__initial_liquid-equivalent_depth",
       "snowpack__liquid-equivalent_depth", 
-      "snowpack__melt_volume_flux", 
+      "snowpack__melt_volume_flux",
       "snowpack__z_mean_of_mass-per-volume_density"
     ]
   }

--- a/snow_energy_balance/db/provides.json
+++ b/snow_energy_balance/db/provides.json
@@ -1,51 +1,18 @@
 [
   {
-    "id": "", 
+    "id": "snow", 
     "required": false, 
     "exchange_items": [
       "model__time_step", 
+      "snowpack__domain_time_integral_of_melt_volume_flux",
       "snowpack__energy-per-area_cold_content", 
+      "snowpack__depth", 
       "snowpack__initial_depth", 
       "snowpack__initial_liquid-equivalent_depth", 
-      "snowpack__z_mean_of_mass-specific_isobaric_heat_capacity"
-    ]
-  }, 
-  {
-    "id": "topoflow", 
-    "required": false, 
-    "exchange_items": [
-      "snowpack__domain_time_integral_of_melt_volume_flux"
-    ]
-  }, 
-  {
-    "id": "evap", 
-    "required": false, 
-    "exchange_items": [
-      "snowpack__depth"
-    ]
-  }, 
-  {
-    "id": "infil", 
-    "required": false, 
-    "exchange_items": [
-      "snowpack__melt_volume_flux"
-    ]
-  }, 
-  {
-    "id": "channels", 
-    "required": false, 
-    "exchange_items": [
-      "snowpack__melt_volume_flux"
-    ]
-  }, 
-  {
-    "id": "met", 
-    "required": false, 
-    "exchange_items": [
-      "snowpack__depth", 
       "snowpack__liquid-equivalent_depth", 
       "snowpack__melt_volume_flux", 
-      "snowpack__z_mean_of_mass-per-volume_density"
+      "snowpack__z_mean_of_mass-per-volume_density",
+      "snowpack__z_mean_of_mass-specific_isobaric_heat_capacity"
     ]
   }
 ]

--- a/topoflow/db/provides.json
+++ b/topoflow/db/provides.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "", 
+    "id": "topoflow", 
     "required": false, 
     "exchange_items": [
       "model__time_step"


### PR DESCRIPTION
Each of the TopoFlow components has a single provides port. I consolidated the information in each component's **provides.json** file into a single JSON object, and set the "id" attribute to the port name listed for the component on the CSDMS web site (e.g. `channels` for [ChannelsDiffWave](http://csdms.colorado.edu/wiki/Model_help:TopoFlow-Channels-Diffusive_Wave)).