### PR TITLE
Clean up TopoFlow component parameters, part 1

### DIFF
--- a/channels_diffusive_wave/db/parameters.json
+++ b/channels_diffusive_wave/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/channels_diffusive_wave/db/parameters.json
+++ b/channels_diffusive_wave/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/channels_diffusive_wave/files/Channels_Diffusive_Wave.cfg.in
+++ b/channels_diffusive_wave/files/Channels_Diffusive_Wave.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: channels_diffusive_wave
 #===============================================================================
 # Input 1
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/channels_dynamic_wave/db/parameters.json
+++ b/channels_dynamic_wave/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/channels_dynamic_wave/db/parameters.json
+++ b/channels_dynamic_wave/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/channels_dynamic_wave/files/Channels_Dynamic_Wave.cfg.in
+++ b/channels_dynamic_wave/files/Channels_Dynamic_Wave.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: channels_dynamic_wave
 #===============================================================================
 # Input 1
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/channels_kinematic_wave/db/parameters.json
+++ b/channels_kinematic_wave/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/channels_kinematic_wave/db/parameters.json
+++ b/channels_kinematic_wave/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/channels_kinematic_wave/files/Channels_Kinematic_Wave.cfg.in
+++ b/channels_kinematic_wave/files/Channels_Kinematic_Wave.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: channels_kinematic_wave
 #===============================================================================
 # Input 1
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/data_his/db/parameters.json
+++ b/data_his/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/data_his/db/parameters.json
+++ b/data_his/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/data_his/files/Data_His.cfg.in
+++ b/data_his/files/Data_His.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: data_his
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/diversions_fraction_method/db/parameters.json
+++ b/diversions_fraction_method/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/diversions_fraction_method/db/parameters.json
+++ b/diversions_fraction_method/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/diversions_fraction_method/files/Diversions_Fraction_Method.cfg.in
+++ b/diversions_fraction_method/files/Diversions_Fraction_Method.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: diversions_fraction_method
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/diversions_standard/db/parameters.json
+++ b/diversions_standard/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/diversions_standard/db/parameters.json
+++ b/diversions_standard/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/diversions_standard/files/Diversions_Standard.cfg.in
+++ b/diversions_standard/files/Diversions_Standard.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: diversions_standard
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/evap_energy_balance/db/parameters.json
+++ b/evap_energy_balance/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/evap_energy_balance/db/parameters.json
+++ b/evap_energy_balance/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/evap_energy_balance/files/Evap_Energy_Balance.cfg.in
+++ b/evap_energy_balance/files/Evap_Energy_Balance.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: evap_energy_balance
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/evap_priestley_taylor/db/parameters.json
+++ b/evap_priestley_taylor/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/evap_priestley_taylor/db/parameters.json
+++ b/evap_priestley_taylor/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/evap_priestley_taylor/files/Evap_Priestley_Taylor.cfg.in
+++ b/evap_priestley_taylor/files/Evap_Priestley_Taylor.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: evap_priestley_taylor
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/evap_read_file/db/parameters.json
+++ b/evap_read_file/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/evap_read_file/db/parameters.json
+++ b/evap_read_file/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/evap_read_file/files/Evap_Read_File.cfg.in
+++ b/evap_read_file/files/Evap_Read_File.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: evap_read_file
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/ice_gc2d/db/parameters.json
+++ b/ice_gc2d/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/ice_gc2d/db/parameters.json
+++ b/ice_gc2d/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/ice_gc2d/files/Ice_Gc2D.cfg.in
+++ b/ice_gc2d/files/Ice_Gc2D.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: ice_gc2d
 #===============================================================================
 # Input 1
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/infil_beven/db/parameters.json
+++ b/infil_beven/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/infil_beven/db/parameters.json
+++ b/infil_beven/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/infil_beven/files/Infil_Beven.cfg.in
+++ b/infil_beven/files/Infil_Beven.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: infil_beven
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/infil_green_ampt/db/parameters.json
+++ b/infil_green_ampt/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/infil_green_ampt/db/parameters.json
+++ b/infil_green_ampt/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/infil_green_ampt/files/Infil_Green_Ampt.cfg.in
+++ b/infil_green_ampt/files/Infil_Green_Ampt.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: infil_green_ampt
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/infil_richards_1d/db/parameters.json
+++ b/infil_richards_1d/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/infil_richards_1d/db/parameters.json
+++ b/infil_richards_1d/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/infil_richards_1d/files/Infil_Richards_1D.cfg.in
+++ b/infil_richards_1d/files/Infil_Richards_1D.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: infil_richards_1d
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/infil_smith_parlange/db/parameters.json
+++ b/infil_smith_parlange/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/infil_smith_parlange/db/parameters.json
+++ b/infil_smith_parlange/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/infil_smith_parlange/files/Infil_Smith_Parlange.cfg.in
+++ b/infil_smith_parlange/files/Infil_Smith_Parlange.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: infil_smith_parlange
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/meteorology/db/parameters.json
+++ b/meteorology/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/meteorology/db/parameters.json
+++ b/meteorology/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/meteorology/files/Meteorology.cfg.in
+++ b/meteorology/files/Meteorology.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: meteorology
 #===============================================================================
 # Input 1
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/satzone_darcy_layers/db/parameters.json
+++ b/satzone_darcy_layers/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/satzone_darcy_layers/db/parameters.json
+++ b/satzone_darcy_layers/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/satzone_darcy_layers/files/Satzone_Darcy_Layers.cfg.in
+++ b/satzone_darcy_layers/files/Satzone_Darcy_Layers.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: satzone_darcy_layers
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/snow_degree_day/db/parameters.json
+++ b/snow_degree_day/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/snow_degree_day/db/parameters.json
+++ b/snow_degree_day/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/snow_degree_day/files/Snow_Degree_Day.cfg.in
+++ b/snow_degree_day/files/Snow_Degree_Day.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: snow_degree_day
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/snow_energy_balance/db/parameters.json
+++ b/snow_energy_balance/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "string", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "string", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/snow_energy_balance/db/parameters.json
+++ b/snow_energy_balance/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/snow_energy_balance/files/Snow_Energy_Balance.cfg.in
+++ b/snow_energy_balance/files/Snow_Energy_Balance.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: snow_energy_balance
 #===============================================================================
 # Input
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | string    | Input directory [-]
 out_directory       | {out_directory}     | string    | Output directory [-]
 site_prefix         | {site_prefix}       | string    | File prefix for the study site [-]

--- a/testservice/db/parameters.json
+++ b/testservice/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "String", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "String", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/testservice/db/parameters.json
+++ b/testservice/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/testservice/files/Testservice.cfg.in
+++ b/testservice/files/Testservice.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: testservice
 #===============================================================================
 # Input Parameters
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | String    | Input directory [-]
 out_directory       | {out_directory}     | String    | Output directory [-]
 site_prefix         | {site_prefix}       | String    | File prefix for the study site [-]

--- a/topoflow/db/parameters.json
+++ b/topoflow/db/parameters.json
@@ -14,26 +14,6 @@
         }
     }, 
     {
-        "key": "in_directory", 
-        "name": "Input directory", 
-        "description": "Input directory", 
-        "value": {
-            "type": "String", 
-            "default": "/home/csdms/models/topoflow/3.1/share/data/treynor_iowa/", 
-            "units": "-"
-        }
-    }, 
-    {
-        "key": "out_directory", 
-        "name": "Output directory", 
-        "description": "Output directory", 
-        "value": {
-            "type": "String", 
-            "default": "~/CMT_Output/", 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/topoflow/db/parameters.json
+++ b/topoflow/db/parameters.json
@@ -1,19 +1,5 @@
 [
     {
-        "key": "comp_status", 
-        "name": "Component status", 
-        "description": "Component status", 
-        "value": {
-            "type": "choice", 
-            "default": "Enabled", 
-            "choices": [
-                "Enabled", 
-                "Disabled"
-            ], 
-            "units": "-"
-        }
-    }, 
-    {
         "key": "site_prefix", 
         "name": "Site prefix", 
         "description": "File prefix for the study site", 

--- a/topoflow/files/Topoflow.cfg.in
+++ b/topoflow/files/Topoflow.cfg.in
@@ -2,7 +2,7 @@
 # Topoflow Config File for: topoflow
 #===============================================================================
 # Input Parameters
-comp_status         | {comp_status}       | choice    | Component status [-] {Enabled; Disabled}
+comp_status         | Enabled             | choice    | Component status [-] {Enabled; Disabled}
 in_directory        | {in_directory}      | String    | Input directory [-]
 out_directory       | {out_directory}     | String    | Output directory [-]
 site_prefix         | {site_prefix}       | String    | File prefix for the study site [-]


### PR DESCRIPTION
I've eliminated the `in_directory` and `out_directory` parameters for each TopoFlow component; they will be set up by WMT, probably with the pre and post hooks that @mcflugen has provided.

I've also hardcoded the `comp_status` parameter to "Enabled". If the component is in WMT, it's enabled.